### PR TITLE
Limit the maximum number of lines in s:refresh_keywords

### DIFF
--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -53,7 +53,9 @@ function! s:refresh_keywords() abort
     if g:asyncomplete_buffer_clear_cache
         let s:words = {}
     endif
-    let l:text = join(getline(1, '$'), "\n")
+    let l:minline = max([1, line('w0') - 500])
+    let l:maxline = min([line('$'), line('w$') + 500])
+    let l:text = join(getline(l:minline, l:maxline), "\n")
     for l:word in split(l:text, '\W\+')
         if len(l:word) > 1
             let s:words[l:word] = 1


### PR DESCRIPTION
Getting the words from the entire buffer will stuck the editor when opening a file over million lines. [Here](https://gist.github.com/itchyny/3cb5a09e190fd1c7da4755d3a51e9a1e) is an example of profiling result where you see much cost in `refresh_keywords`.  I want to limit the number of lines.