### PR TITLE
Add max_buffer_size option to limit the buffer size for completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,12 @@ call asyncomplete#register_source(asyncomplete#sources#buffer#get_source_options
     \ 'whitelist': ['*'],
     \ 'blacklist': ['go'],
     \ 'completor': function('asyncomplete#sources#buffer#completor'),
+    \ 'config': {
+    \    'max_buffer_size': 5000000,
+    \  },
     \ }))
 ```
+Note: config is optional. `max_buffer_size` defaults to 5000000 (5mb). If the buffer size exceeds `max_buffer_size` it is ignored. Set `max_buffer_size` to -1 for unlimited buffer size.
 
 ### Options
 

--- a/autoload/asyncomplete/sources/buffer.vim
+++ b/autoload/asyncomplete/sources/buffer.vim
@@ -38,6 +38,18 @@ endfunction
 
 let s:last_ctx = {}
 function! s:on_event(opt, ctx, event) abort
+    let l:max_buffer_size = 5000000 " 5mb
+    if has_key(a:opt, 'config') && has_key(a:opt['config'], 'max_buffer_size')
+        let l:max_buffer_size = a:opt['config']['max_buffer_size']
+    endif
+    if l:max_buffer_size != -1
+        let l:buffer_size = line2byte(line('$') + 1)
+        if l:buffer_size > l:max_buffer_size
+            call asyncomplete#log('ignoring buffer due to large size', expand('%:p'), l:buffer_size)
+            return
+        endif
+    endif
+
     if a:event == 'TextChangedI'
         call s:refresh_keyword_incr(a:ctx['typed'])
     else


### PR DESCRIPTION
Due to https://github.com/prabirshrestha/asyncomplete-buffer.vim/pull/8#issuecomment-502155917, I implemented a new option to abort the completion based on buffer size.